### PR TITLE
Add missing field

### DIFF
--- a/jbm-ebpf/src/main.rs
+++ b/jbm-ebpf/src/main.rs
@@ -35,6 +35,7 @@ static CONFIG: Config = Config {
     target_tgid: 0,
     min_block_us: 0,
     max_block_us: 0,
+    stack_storage_size: 0,
 };
 
 #[kprobe(name = "jbm")]


### PR DESCRIPTION
Hi, thank you for publishing this tool.

I couldn't build this by following errors.

```
error[E0063]: missing field `stack_storage_size` in initializer of `Config`
--> src/main.rs:34:25
|
| static CONFIG: Config = Config {
|                         ^^^^^^ missing `stack_storage_size`

For more information about this error, try `rustc --explain E0063`.
error: could not compile `jbm-ebpf` (bin "jbm") due to previous error
```
